### PR TITLE
Image collection vc with rendered pdf

### DIFF
--- a/taz.neo/AppDelegate.swift
+++ b/taz.neo/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: NotifiedDelegate {
   
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     self.window = UIWindow(frame: UIScreen.main.bounds)
-    self.window?.rootViewController = MainNC()
+//    self.window?.rootViewController = MainNC()
 //    self.window?.rootViewController = NavController()
 //    self.window?.rootViewController = ContentVC()
 //    self.window?.rootViewController = UITests()
@@ -25,7 +25,7 @@ class AppDelegate: NotifiedDelegate {
 //    self.window?.rootViewController = WebViewTests()
 //    self.window?.rootViewController = SliderTest()
 //    self.window?.rootViewController = ColorTests()
-//    self.window?.rootViewController = PdfTest()
+    self.window?.rootViewController = PdfTest()
     self.window?.makeKeyAndVisible()
     if let shortcutItem = launchOptions?[UIApplication.LaunchOptionsKey.shortcutItem] as? UIApplicationShortcutItem {
       if shortcutItem.type == "Logging" { wantLogging = true }

--- a/taz.neo/TestController/PdfTest.swift
+++ b/taz.neo/TestController/PdfTest.swift
@@ -8,39 +8,107 @@
 import UIKit
 import NorthLib
 
-class PdfTest: UIViewController {
-  var imageView = ImageView()
-  var pdfs = ["s1.pdf", "s2.pdf", "s3.pdf"]
-  var current: Int?
-  var nextPdf: PdfDoc { 
-    if var i = current {
-      if i == 2 { i = 0 }
-      else { i += 1 }
-      current = i
-    }
-    else { current = 0 }
-    return PdfDoc(fname: File(inMain: pdfs[current!])!.path)
-  }
 
-  func showNext() {
-    if let img = nextPdf[0]?.image(width: UIScreen.main.bounds.width*2) {
-      self.imageView.image = img
-    }
+public class ZoomedPdfImage: OptionalImageItem {
+  
+  public var pdfFilename: String?
+  public var detailZoomScale: CGFloat?
+  
+  public required init(pdfFilename: String?) {
+    self.pdfFilename = pdfFilename
   }
+  
+  required init(waitingImage: UIImage? = nil) {
+    fatalError("init(waitingImage:) has not been implemented")
+  }
+}
+
+class PdfTest: ImageCollectionVC, CanRotate {
+  
+  /// Light status bar because of black background
+  override public var preferredStatusBarStyle: UIStatusBarStyle { .lightContent }
+  
+  var logView = TestView()
+  lazy var consoleLogger = Log.Logger()
+  lazy var viewLogger = Log.ViewLogger()
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    self.view.addSubview(self.imageView)
-    self.imageView.pinWidth(self.view.bounds.size.width)
-    //self.imageView.pinAspect(ratio: img.size.width/img.size.height)
-    pin(self.imageView.centerX, to: self.view.centerX)
-    pin(self.imageView.centerY, to: self.view.centerY)
+    Log.minLogLevel = .Debug
+    Log.append(logger: consoleLogger, viewLogger)
+    let nd = NotifiedDelegate.singleton!
+    nd.statusBar.backgroundColor = UIColor.green
+    nd.onSbTap { view in
+      self.debug("Tapped")
+    }
+    nd.permitPush { pn in
+      if pn.isPermitted { self.debug("Permission granted") }
+      else { self.debug("No permission") }
+    }
+    nd.onReceivePush { (pn, payload) in
+      self.debug(payload.toString())
+    }
+    self.view.backgroundColor = UIColor.red
+    self.collectionView.backgroundColor = UIColor.blue
+    
+    
+    for pdf in ["s1.pdf", "s2.pdf", "s3.pdf"] {
+      self.images.append(ZoomedPdfImage(pdfFilename: pdf))
+    }
+    
+    for zoomedPdfImage in self.images {
+      guard let zoomedPdfImage = zoomedPdfImage as? ZoomedPdfImage,
+        let filename = zoomedPdfImage.pdfFilename else { continue }
+      /// **Optional:** generate preview Image
+      zoomedPdfImage.waitingImage = PdfDoc(fname: File(inMain: filename)!.path)[0]?
+        .image(width: UIScreen.main.bounds.width/4)
+      zoomedPdfImage.detailZoomScale = 0.25
+      ///append HighResRequested Handler
+      zoomedPdfImage.onHighResImgNeeded(zoomFactor: 1.1) { (callback: @escaping (UIImage?) -> ()) in
+        DispatchQueue(label: "pdfrender.detail.serial.queue").async {
+          guard let filename = zoomedPdfImage.pdfFilename else { return }
+          let nextZoomScale = (zoomedPdfImage.detailZoomScale ?? 0) * 2
+          print("nextZoomScale:", nextZoomScale)
+          let img = PdfDoc(fname: File(inMain: filename)!.path)[0]?
+            .image(width: UIScreen.main.bounds.width*nextZoomScale)
+          zoomedPdfImage.detailZoomScale = nextZoomScale
+          DispatchQueue.main.async {
+            if img?.size == CGSize.zero {
+              self.error("PDF Renderer returned Empty Image,"
+                      + " this happens in high Zoom Scales!")
+              callback(nil)
+            }
+            else {
+              self.error("PDF Renderer returned Image:"
+                       + " \(String.init(describing: img))")
+               callback(img)
+            }
+          }
+        }
+      }
+      
+      zoomedPdfImage.onTap { (x, y) in
+        self.log("You Tapped at: \(x),\(y)"
+               + " in \(zoomedPdfImage.pdfFilename ?? "-")")
+      }
+      
+      DispatchQueue(label: "pdfrender.serial.queue").async {
+        self.renderInitialPdfs()
+      }
+    }
   }
   
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
-    showNext()
-    every(seconds: 1.0) {_ in self.showNext() }
-  }  
-
+  private func renderInitialPdfs(){
+    for zoomedPdfImage in self.images {
+      guard let zoomedPdfImage = zoomedPdfImage as? ZoomedPdfImage,
+        let filename = zoomedPdfImage.pdfFilename else { continue }
+      let img = PdfDoc(fname: File(inMain: filename)!.path)[0]?
+        .image(width: UIScreen.main.bounds.width*2)
+      DispatchQueue.main.async {
+        zoomedPdfImage.image = img
+        zoomedPdfImage.detailZoomScale = 2
+      }
+    }
+  }
+  
 } // PdfTest


### PR DESCRIPTION
Known Issues:
- Crash on out of memory due to rendering large PDFs in a concurrent thread
- if zoom scale too height PDF Renderer returns an empty image, wich stops requesting higher detail images