### PR TITLE
Fix buildphrases for optional ressources

### DIFF
--- a/taz.neo.xcodeproj/project.pbxproj
+++ b/taz.neo.xcodeproj/project.pbxproj
@@ -46,8 +46,6 @@
 		AECCE11A23FBF07B007C2276 /* SectionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE4AA2B123F6AD9100EAFE78 /* SectionVC.swift */; };
 		AECCE11C23FBF3FE007C2276 /* MainNC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECCE11B23FBF3FE007C2276 /* MainNC.swift */; };
 		AECCE11E23FBF449007C2276 /* StartupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECCE11D23FBF449007C2276 /* StartupView.swift */; };
-		AED52FC92492763100CC082E /* Aktiv Grotesk Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AED52FC62492763100CC082E /* Aktiv Grotesk Bold.ttf */; };
-		AED52FCC2492768F00CC082E /* Aktiv Grotesk.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AED52FCB2492768F00CC082E /* Aktiv Grotesk.ttf */; };
 		AED748A62383F1D600C09D2D /* ArticleDB.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = AED70C8E2243E0EB00487918 /* ArticleDB.xcdatamodel */; };
 		AED748AB238415B200C09D2D /* NorthLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE98512D2320F83900EAC9D8 /* NorthLib.framework */; };
 		AEED41BC23FE8E6F0072043F /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEED41BB23FE8E6F0072043F /* Authentication.swift */; };
@@ -370,11 +368,9 @@
 				AE864874248E3168007096B4 /* s2.pdf in Resources */,
 				AE5D9EC423E1BB2D0002C3B8 /* ContentTableVC.xib in Resources */,
 				AE864876248E316D007096B4 /* s3.pdf in Resources */,
-				AED52FCC2492768F00CC082E /* Aktiv Grotesk.ttf in Resources */,
 				AEBAF572219ACD1A00566205 /* LaunchScreen.storyboard in Resources */,
 				AE864872248E3162007096B4 /* s1.pdf in Resources */,
 				AEBAF56F219ACD1A00566205 /* Assets.xcassets in Resources */,
-				AED52FC92492763100CC082E /* Aktiv Grotesk Bold.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/taz.neo.xcodeproj/project.pbxproj
+++ b/taz.neo.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 				AEBAF560219ACD1900566205 /* Sources */,
 				AEBAF561219ACD1900566205 /* Frameworks */,
 				AEBAF562219ACD1900566205 /* Resources */,
+				00B1A85924A3A1050041B9C5 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -375,6 +376,30 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00B1A85924A3A1050041B9C5 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/$(PROJECT_NAME)/Supporting Files/Fonts/Aktiv Grotesk Bold.ttf",
+				"$(SRCROOT)/$(PROJECT_NAME)/Supporting Files/Fonts/Aktiv Grotesk.ttf",
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Aktiv Grotesk Bold.ttf",
+				"${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Aktiv Grotesk.ttf",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "COUNTER=0\nwhile [ $COUNTER -lt ${SCRIPT_INPUT_FILE_COUNT} ]; do\n  FILE_IN=\"SCRIPT_INPUT_FILE_$COUNTER\"\n  FILE_OUT=\"SCRIPT_OUTPUT_FILE_$COUNTER\"\n  ls \"${!FILE_IN}\"\n  if [ -f \"${!FILE_IN}\" ]; then\n    cp \"${!FILE_IN}\" \"${!FILE_OUT}\"\n    echo \"copied ${!FILE_IN} to Intermediate Folder: ${!FILE_OUT}\"\n  else\n    echo \"Optional File not found at ${!FILE_IN}, and will be 'MISSING'\"\n  fi\n  let COUNTER=COUNTER+1\ndone\necho \"done\"\nexit 0\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		AEBAF560219ACD1900566205 /* Sources */ = {

--- a/taz.neo/TestController/UITests.swift
+++ b/taz.neo/TestController/UITests.swift
@@ -59,26 +59,26 @@ class UITests: UIViewController {
       print(symButton.frame)      
     }
     //buildPinExample()
-//    let label = UILabel()
-//    label.font = UIFont(name: "TazAppIcons-Regular", size: 16)!
-//    label.text = "ALSXabcdehilstvx"
-//    label.backgroundColor = UIColor.rgb(0xdddddd)
-//    self.view.addSubview(label)
-//    pin(label.centerX, to: self.view.centerX)
-//    pin(label.centerY, to: self.view.centerY)
-//    let biv = Button<SImageView>()
-//    let iv = biv.buttonView
-//      iv.symbol = "trash"
-//      view.addSubview(biv)
-//      pin(biv.centerX, to: self.view.centerX)
-//      pin(biv.centerY, to: self.view.centerY)
-//      biv.pinWidth(100)
-//      biv.pinHeight(100)
-//      biv.backgroundColor = .blue
-//      iv.backgroundColor = .yellow
-//      biv.onPress {_ in
-//        print("button press")
-//      }
+    //    let label = UILabel()
+    //    label.font = UIFont(name: "TazAppIcons-Regular", size: 16)!
+    //    label.text = "ALSXabcdehilstvx"
+    //    label.backgroundColor = UIColor.rgb(0xdddddd)
+    //    self.view.addSubview(label)
+    //    pin(label.centerX, to: self.view.centerX)
+    //    pin(label.centerY, to: self.view.centerY)
+    //    let biv = Button<SImageView>()
+    //    let iv = biv.buttonView
+    //      iv.symbol = "trash"
+    //      view.addSubview(biv)
+    //      pin(biv.centerX, to: self.view.centerX)
+    //      pin(biv.centerY, to: self.view.centerY)
+    //      biv.pinWidth(100)
+    //      biv.pinHeight(100)
+    //      biv.backgroundColor = .blue
+    //      iv.backgroundColor = .yellow
+    //      biv.onPress {_ in
+    //        print("button press")
+    //      }
     
   }
   
@@ -118,15 +118,46 @@ class UITests: UIViewController {
     print("release:  \(Utsname.release)")
     print("version:  \(Utsname.version)")
     print("machine:  \(Utsname.machine)")
+    var offset : CGFloat = 20
+    let demo = "\nAaBbCcDdEeFfGgHh@§$%&?ßöäü"
+    //    static var contentFontName: String? = UIFont.register(name: "Aktiv Grotesk")
+    //    static var titleFontName: String? = UIFont.register(name: "Aktiv Grotesk Bold")
     if let fontName = UIFont.register(name: "Aktiv Grotesk Bold"),
-       let font = UIFont(name: fontName, size: 20) {
+      let font = UIFont(name: fontName, size: 20) {
       let label = UILabel()
       label.font = font
-      label.text = "Family: \(font.familyName), Name: \(font.fontName)"
+      label.text = "Family: \(font.familyName), \nName: \(font.fontName)\(demo)"
+      label.numberOfLines = 3
       self.view.addSubview(label)
-      pin(label.top, to: self.view.topGuide(), dist: 20)
+      pin(label.top, to: self.view.topGuide(), dist: offset)
       pin(label.left, to: self.view.leftGuide(), dist: 20)
+      pin(label.right, to: self.view.rightGuide(), dist: 20)
+      offset += 90
     }
+    
+    if let fontName = UIFont.register(name: "Aktiv Grotesk"),
+      let font = UIFont(name: fontName, size: 20) {
+      let label = UILabel()
+      label.font = font
+      label.text = "Family: \(font.familyName), \nName: \(font.fontName)\(demo)"
+      label.numberOfLines = 3
+      self.view.addSubview(label)
+      pin(label.top, to: self.view.topGuide(), dist: offset)
+      pin(label.left, to: self.view.leftGuide(), dist: 20)
+      pin(label.right, to: self.view.rightGuide(), dist: 20)
+      offset += 90
+    }
+    
+    let label = UILabel()
+    let font = UIFont.systemFont(ofSize: 20)
+    label.font = font
+    label.text = "Family: \(font.familyName), \nName: \(font.fontName)\(demo)"
+    label.numberOfLines = 3
+    self.view.addSubview(label)
+    pin(label.top, to: self.view.topGuide(), dist: offset)
+    pin(label.left, to: self.view.leftGuide(), dist: 20)
+    pin(label.right, to: self.view.rightGuide(), dist: 20)
+  
   }
   
   func printFontNames() {
@@ -149,24 +180,24 @@ class UITests: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.view.backgroundColor = UIColor.white
-    pinTest()
+    //    pinTest()
     //loadingTest()
     //undefinedTest()
     //startupViewTest()
     //delay(seconds: 2) { self.alertTest() }
     //gifTest()
-    //fontTest()
+    fontTest()
     //alertTest()
     //printFontNames()
   }
   
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-//    print(self.undefinedView.frame)
-//    print(self.undefinedView.label.frame)
-//    print(self.view.frame)
-//    print(toolBar.frame)
-//    print(backButton.frame)
+    //    print(self.undefinedView.frame)
+    //    print(self.undefinedView.label.frame)
+    //    print(self.view.frame)
+    //    print(toolBar.frame)
+    //    print(backButton.frame)
   }
   
 }


### PR DESCRIPTION
Added build phrases "shell build script" that copies and adds all files listed in input/output pairs to the intermediate build folder, to use non-public files if they exist on the build machine
added used fonts to that in/output pairs
Notes:
- Attention need to use ${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/... as output Path, otherwise the build environment did not recognize that these files need to be added to target
- use Clean Build to test if the files are removed
- just drop the files to Fonts folder to test if they are added
- use AppDelegate's UITest Controller to check if the fonts work