### PR TITLE
tazID Bugfixes

### DIFF
--- a/taz.neo/Views/Forms/ConnectTazIdView.swift
+++ b/taz.neo/Views/Forms/ConnectTazIdView.swift
@@ -108,6 +108,7 @@ public class ConnectTazIdView : FormView{
       pass2Input.bottomMessage = Localized("login_password_error_empty")
     }
     else if pass2Input.text != passInput.text {
+      errors = true
       pass2Input.bottomMessage = Localized("login_password_confirmation_error_match")
     }
     

--- a/taz.neo/Views/Forms/TrialSubscriptionView.swift
+++ b/taz.neo/Views/Forms/TrialSubscriptionView.swift
@@ -9,7 +9,23 @@
 import UIKit
 import NorthLib
 
+extension TrialSubscriptionView : UITextFieldDelegate {
+  public func textFieldDidBeginEditing(_ textField: UITextField) {
+    if exchangeResponder == false {
+      exchangeResponder = true
+      firstnameInput.becomeFirstResponder()
+      textField.becomeFirstResponder()
+      exchangeResponder = false
+    }
+    
+  }
+}
+
+
+
 public class TrialSubscriptionView : FormView{
+  
+  var exchangeResponder = false
   
   var mailInput = TazTextField(placeholder: Localized("login_email_hint"),
                                textContentType: .emailAddress,
@@ -57,6 +73,12 @@ public class TrialSubscriptionView : FormView{
   }()
   
   override func createSubviews() -> [UIView] {
+    if #available(iOS 12.0, *) {
+      passInput.textContentType = .newPassword
+    }
+    passInput.delegate = self
+    pass2Input.delegate = self
+    
     return   [
       TazHeader(),
       Padded.Label(title: Localized("trial_subscription_title")),

--- a/taz.neo/Views/Forms/TrialSubscriptionView.swift
+++ b/taz.neo/Views/Forms/TrialSubscriptionView.swift
@@ -107,6 +107,7 @@ public class TrialSubscriptionView : FormView{
       pass2Input.bottomMessage = Localized("login_password_error_empty")
     }
     else if pass2Input.isUsed, pass2Input.text != passInput.text {
+      errors = true
       pass2Input.bottomMessage = Localized("login_password_confirmation_error_match")
     }
     


### PR DESCRIPTION
- Password Field Keyboard Language is same Language like for other Input Fields
- enable password & password repetition check in trialSubscription and tazID Create