### PR TITLE
RC 0.4.7

### DIFF
--- a/taz.neo.xcodeproj/project.pbxproj
+++ b/taz.neo.xcodeproj/project.pbxproj
@@ -690,7 +690,7 @@
 				CODE_SIGN_ENTITLEMENTS = "taz.neo/Supporting Files/taz.neo.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2020090901;
+				CURRENT_PROJECT_VERSION = 2020090951;
 				DEVELOPMENT_TEAM = 3R3GBCY6FA;
 				INFOPLIST_FILE = "$(SRCROOT)/taz.neo/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
@@ -698,7 +698,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.6;
+				MARKETING_VERSION = 0.4.7;
 				PRODUCT_BUNDLE_IDENTIFIER = de.taz.taz.2;
 				PRODUCT_NAME = "taz App";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -716,7 +716,7 @@
 				CODE_SIGN_ENTITLEMENTS = "taz.neo/Supporting Files/taz.neo.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2020090901;
+				CURRENT_PROJECT_VERSION = 2020090951;
 				DEVELOPMENT_TEAM = 3R3GBCY6FA;
 				INFOPLIST_FILE = "$(SRCROOT)/taz.neo/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
@@ -724,7 +724,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.6;
+				MARKETING_VERSION = 0.4.7;
 				PRODUCT_BUNDLE_IDENTIFIER = de.taz.taz.2;
 				PRODUCT_NAME = "taz App";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/taz.neo/Supporting Files/Base.lproj/Localizable.strings
+++ b/taz.neo/Supporting Files/Base.lproj/Localizable.strings
@@ -36,6 +36,8 @@
 
 /* translation from Android */
 "ask_for_trial_subscription_title" = "Möchten Sie die digitale Ausgabe der taz 14 Tage kostenlos testen?";
+"no_mail_title" = "Achtung";
+"no_mail_text" = "Zum Senden des Feedbacks verwendet diese App die iOS Mail Funktionalität.\nLeider kann derzeit von Ihrem Gerät keine E-Mail versendet werden. Bitte überprüfen Sie die Einstellungen zum Senden von E-Mails oder senden Sie Ihr Feedback direkt an: digiabo@taz.de.\nBei Problemen oder Rückfragen geben Sie bitte auch Ihre taz-ID oder Abo-ID an.";
 
 /* translation from Android */
 "register_button" = "Registrieren";

--- a/taz.neo/Supporting Files/Base.lproj/Localizable.strings
+++ b/taz.neo/Supporting Files/Base.lproj/Localizable.strings
@@ -32,15 +32,21 @@
 "help" = "Hilfe";
 
 /* translation from Android */
-"trial_subscription_title" = "Sie möchten die digitale Ausgabe der taz 14 Tage kostenlos testen?";
+"trial_subscription_title" = "Sie möchten die digitale Ausgabe der taz 6 Wochen kostenlos testen?";
 
 /* translation from Android */
-"ask_for_trial_subscription_title" = "Möchten Sie die digitale Ausgabe der taz 14 Tage kostenlos testen?";
+"ask_for_trial_subscription_title" = "Möchten Sie die digitale Ausgabe der taz 6 Wochen kostenlos testen?";
+
+
 "no_mail_title" = "Achtung";
 "no_mail_text" = "Zum Senden des Feedbacks verwendet diese App die iOS Mail Funktionalität.\nLeider kann derzeit von Ihrem Gerät keine E-Mail versendet werden. Bitte überprüfen Sie die Einstellungen zum Senden von E-Mails oder senden Sie Ihr Feedback direkt an: digiabo@taz.de.\nBei Problemen oder Rückfragen geben Sie bitte auch Ihre taz-ID oder Abo-ID an.";
 
 /* translation from Android */
 "register_button" = "Registrieren";
+
+"register_tips_button" = "Hinweise zum taz Probeabo";
+
+"register_tips_text" = "Nach Ihrer Bestellung erhalten Sie eine Bestätigungs-E-Mail mit Aktivierungs-Link. Durch Aufruf dieses Links, wird Ihr Probeabo aktiviert. Sollten Sie diese E-Mail nicht erhalten, überprüfen Sie bitte Ihren Spam Ordner.\nDie digitale Ausgabe der taz steht Ihnen bereits am Vorabend des Erscheinungstages in der App zur Verfügung.\nDas Probeabo endet automatisch.";
 
 /* translation from Android */
 "login_forgot_password" = "Haben Sie Ihr Passwort vergessen?";

--- a/taz.neo/ViewController/ContentVC.swift
+++ b/taz.neo/ViewController/ContentVC.swift
@@ -363,12 +363,14 @@ open class ContentVC: WebViewCollectionVC, IssueInfo, UIStyleChangeDelegate {
   }
   
   public func applyStyles() {
-      slider.button.layer.shadowColor = Const.SetColor.CTDate.color.cgColor
-      settingsBottomSheet.color = Const.SetColor.ios(.secondarySystemBackground).color
-      settingsBottomSheet.handleColor = Const.SetColor.ios(.opaqueSeparator).color
-      writeTazApiCss{
-        super.reloadAllWebViews()
-      }
+    slider.button.layer.shadowColor = Const.SetColor.CTDate.color.cgColor
+    settingsBottomSheet.color = Const.SetColor.ios(.secondarySystemBackground).color
+    settingsBottomSheet.handleColor = Const.SetColor.ios(.opaqueSeparator).color
+    self.collectionView.backgroundColor = Const.SetColor.CTBackground.color
+    self.view.backgroundColor = Const.SetColor.CTBackground.color
+    writeTazApiCss{
+      super.reloadAllWebViews()
+    }
   }
   
   open override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/taz.neo/ViewController/ContentVC.swift
+++ b/taz.neo/ViewController/ContentVC.swift
@@ -384,6 +384,7 @@ open class ContentVC: WebViewCollectionVC, IssueInfo, UIStyleChangeDelegate {
   override public func viewDidDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
     slider.close()
+    self.settingsBottomSheet.close()
     if let overlay = imageOverlay { overlay.close(animated: false) }
   }
 

--- a/taz.neo/ViewController/ContentVC.swift
+++ b/taz.neo/ViewController/ContentVC.swift
@@ -274,7 +274,13 @@ open class ContentVC: WebViewCollectionVC, IssueInfo, UIStyleChangeDelegate {
     onSettings{ [weak self] _ in
       guard let self = self else { return }
       self.debug("*** Action: <Settings> pressed")
-      self.settingsBottomSheet.open()
+      if self.settingsBottomSheet.isOpen {
+          self.settingsBottomSheet.close()
+      }
+      else {
+        self.settingsBottomSheet.open()
+      }
+      
       self.textSettingsVC.updateButtonValuesOnOpen()
     }
   }

--- a/taz.neo/ViewController/Forms/PwForgotController.swift
+++ b/taz.neo/ViewController/Forms/PwForgotController.swift
@@ -185,7 +185,14 @@ class SubscriptionResetSuccessController: FormsResultController, MFMailComposeVi
   
   // MARK: handleMail Action
   @IBAction func handleMail(_ sender: UIButton) {
-    if MFMailComposeViewController.canSendMail() == false { return }
+    if MFMailComposeViewController.canSendMail() == false {
+      if sender.isEnabled == false { return }
+      sender.isEnabled = false
+      Alert.message(title: Localized("no_mail_title"), message: Localized("no_mail_text"), closure: {
+        sender.isEnabled = true
+      })
+      return
+    }
     
     let composeVC = MFMailComposeViewController()
     composeVC.mailComposeDelegate = self

--- a/taz.neo/ViewController/Forms/TrialSubscriptionController.swift
+++ b/taz.neo/ViewController/Forms/TrialSubscriptionController.swift
@@ -179,6 +179,8 @@ class TrialSubscriptionRequestNameCtrl : TrialSubscriptionController{
          ui.agbAcceptTV,
          ui.registerButton,
          ui.cancelButton,
+         ui.registerTipsButton
+
        ]
      }
   

--- a/taz.neo/Views/Forms/ConnectTazIdView.swift
+++ b/taz.neo/Views/Forms/ConnectTazIdView.swift
@@ -8,7 +8,20 @@
 import UIKit
 import NorthLib
 
+extension ConnectTazIdView : UITextFieldDelegate {
+  public func textFieldDidBeginEditing(_ textField: UITextField) {
+    if exchangeResponder == false {
+      exchangeResponder = true
+      firstnameInput.becomeFirstResponder()
+      textField.becomeFirstResponder()
+      exchangeResponder = false
+    }
+  }
+}
+
 public class ConnectTazIdView : FormView{
+  
+  var exchangeResponder = false
   
   var mailInput = TazTextField(placeholder: Localized("login_email_hint"),
                                textContentType: .emailAddress,
@@ -60,6 +73,12 @@ public class ConnectTazIdView : FormView{
   }()
   
   override func createSubviews() -> [UIView] {
+    if #available(iOS 12.0, *) {
+      passInput.textContentType = .newPassword
+    }
+    passInput.delegate = self
+    pass2Input.delegate = self
+    
     return [
       TazHeader(),
       Padded.Label(title: Localized("taz_id_account_create_intro")),

--- a/taz.neo/Views/Forms/FormView.swift
+++ b/taz.neo/Views/Forms/FormView.swift
@@ -84,6 +84,21 @@ public class FormView: UIView {
   }
 }
 
+extension FormView {
+  @objc public func showRegisterTips(_ textField: UITextField) {
+     Alert.message(title: Localized("register_tips_button"), message: Localized("register_tips_text"))
+  }
+  
+  var registerTipsButton:UIButton{
+    get{
+      return Padded.Button(type: .label,
+                           title: Localized("register_tips_button"),
+                           target: self,
+                           action: #selector(showRegisterTips))
+    }
+  }
+}
+
 // MARK: Keyboard Action, set ScrollView Insets if Keyboard appears
 extension FormView {
   fileprivate func setKeyboardObserving(){

--- a/taz.neo/Views/Forms/TrialSubscriptionView.swift
+++ b/taz.neo/Views/Forms/TrialSubscriptionView.swift
@@ -17,11 +17,8 @@ extension TrialSubscriptionView : UITextFieldDelegate {
       textField.becomeFirstResponder()
       exchangeResponder = false
     }
-    
   }
 }
-
-
 
 public class TrialSubscriptionView : FormView{
   
@@ -60,7 +57,6 @@ public class TrialSubscriptionView : FormView{
   
   var cancelButton =  Padded.Button(type:.outline, title: Localized("cancel_button"))
   
-  
   // MARK: agbAcceptLabel with Checkbox
   lazy var agbAcceptTV : CheckboxWithText = {
     let view = CheckboxWithText()
@@ -71,7 +67,7 @@ public class TrialSubscriptionView : FormView{
     view.textView.textColor = Const.SetColor.HText.color
     return view
   }()
-  
+    
   override func createSubviews() -> [UIView] {
     if #available(iOS 12.0, *) {
       passInput.textContentType = .newPassword

--- a/taz.neo/Views/Forms/TrialSubscriptionView.swift
+++ b/taz.neo/Views/Forms/TrialSubscriptionView.swift
@@ -87,7 +87,8 @@ public class TrialSubscriptionView : FormView{
         Localized("fragment_login_request_test_subscription_existing_account")),
       agbAcceptTV,
       registerButton,
-      cancelButton
+      cancelButton,
+      registerTipsButton
     ]
   }
   

--- a/taz.neo/Views/LoadingView.swift
+++ b/taz.neo/Views/LoadingView.swift
@@ -11,7 +11,7 @@ import NorthLib
 fileprivate var TopFont = UIFont.boldSystemFont(ofSize: 24)
 fileprivate var BottomFont = UIFont.boldSystemFont(ofSize: 18)
 
-open class LoadingView: UIView {
+open class LoadingView: UIView, UIStyleChangeDelegate {
   
   private var stack = UIStackView()
   private var topLabel = UILabel()
@@ -31,6 +31,7 @@ open class LoadingView: UIView {
   public func stop() { spinner.stopAnimating() }
   
   private func setup() {
+    registerForStyleUpdates()
     backgroundColor = UIColor.clear
     topLabel.font = TopFont
     topLabel.numberOfLines = 0
@@ -38,10 +39,11 @@ open class LoadingView: UIView {
     bottomLabel.font = BottomFont
     bottomLabel.numberOfLines = 0
     bottomLabel.textAlignment = .center
+
     if #available(iOS 13.0, *) {
       spinner.style = .large
     }
-    spinner.color = UIColor.black
+
     spinner.startAnimating()
     for view in [topLabel, spinner, bottomLabel] {
       stack.addArrangedSubview(view)
@@ -50,6 +52,12 @@ open class LoadingView: UIView {
     stack.distribution = .fillEqually
     addSubview(stack)
     pin(stack, to: self)
+  }
+  
+  public func applyStyles(){
+    spinner.color = Const.SetColor.CTDate.color
+    topLabel.textColor = Const.SetColor.CTDate.color
+    bottomLabel.textColor = Const.SetColor.CTDate.color
   }
   
   public override init(frame: CGRect) {


### PR DESCRIPTION
- improved Feedback Mail (taz-ID, Alert if no Mail available)
- 6 weeks trails subscription text, tooltip text for trial
- fix German Keyboard Issue for tazIdconnect Register Form 
- settings bottom sheet close/open
- darkmode ios 12 fixes (loading view, articleVC StatusBar)
requires update to northLib #cad5909