### PR TITLE
Fix wrong Keyboard

### DIFF
--- a/taz.neo.xcodeproj/project.pbxproj
+++ b/taz.neo.xcodeproj/project.pbxproj
@@ -690,7 +690,7 @@
 				CODE_SIGN_ENTITLEMENTS = "taz.neo/Supporting Files/taz.neo.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2020091451;
+				CURRENT_PROJECT_VERSION = 2020091452;
 				DEVELOPMENT_TEAM = 3R3GBCY6FA;
 				INFOPLIST_FILE = "$(SRCROOT)/taz.neo/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
@@ -698,8 +698,8 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.9;
-				PRODUCT_BUNDLE_IDENTIFIER = de.taz.taz.2;
+				MARKETING_VERSION = 0.4.10;
+				PRODUCT_BUNDLE_IDENTIFIER = de.taz.taz.neo;
 				PRODUCT_NAME = "taz App";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -716,7 +716,7 @@
 				CODE_SIGN_ENTITLEMENTS = "taz.neo/Supporting Files/taz.neo.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2020091451;
+				CURRENT_PROJECT_VERSION = 2020091452;
 				DEVELOPMENT_TEAM = 3R3GBCY6FA;
 				INFOPLIST_FILE = "$(SRCROOT)/taz.neo/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
@@ -724,8 +724,8 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.9;
-				PRODUCT_BUNDLE_IDENTIFIER = de.taz.taz.2;
+				MARKETING_VERSION = 0.4.10;
+				PRODUCT_BUNDLE_IDENTIFIER = de.taz.taz.neo;
 				PRODUCT_NAME = "taz App";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/taz.neo/ConfigDefaults.swift
+++ b/taz.neo/ConfigDefaults.swift
@@ -35,5 +35,5 @@ public let ConfigDefaults = Defaults.Values([
   // Allow automatic download over mobile networks
   "autoMobileDownloads" : "false",
   // Allow trial subscriptions
-  "offerTrialSubscription" : "false",
+  "offerTrialSubscription" : "true",
 ])

--- a/taz.neo/Views/Forms/ConnectTazIdView.swift
+++ b/taz.neo/Views/Forms/ConnectTazIdView.swift
@@ -43,13 +43,13 @@ public class ConnectTazIdView : FormView{
   var firstnameInput = TazTextField(placeholder: Localized("login_first_name_hint"),
                                     textContentType: .givenName,
                                     enablesReturnKeyAutomatically: true,
-                                    keyboardType: .namePhonePad,
+                                    keyboardType: .default,
                                     autocapitalizationType: .words)
   
   var lastnameInput = TazTextField(placeholder: Localized("login_surname_hint"),
                                    textContentType: .familyName,
                                    enablesReturnKeyAutomatically: true,
-                                   keyboardType: .namePhonePad,
+                                   keyboardType: .default,
                                    autocapitalizationType: .words)
   
   var alreadyHaveTazIdButton = Padded.Button(type: .label,

--- a/taz.neo/Views/Forms/TrialSubscriptionView.swift
+++ b/taz.neo/Views/Forms/TrialSubscriptionView.swift
@@ -44,13 +44,13 @@ public class TrialSubscriptionView : FormView{
   var firstnameInput = TazTextField(placeholder: Localized("login_first_name_hint"),
                                     textContentType: .givenName,
                                     enablesReturnKeyAutomatically: true,
-                                    keyboardType: .namePhonePad,
+                                    keyboardType: .default,
                                     autocapitalizationType: .words)
   
   var lastnameInput = TazTextField(placeholder: Localized("login_surname_hint"),
                                    textContentType: .familyName,
                                    enablesReturnKeyAutomatically: true,
-                                   keyboardType: .namePhonePad,
+                                   keyboardType: .default,
                                    autocapitalizationType: .words)
   
   var registerButton = Padded.Button(title: Localized("register_button"))


### PR DESCRIPTION
In ConnectTazIdView.swift, TrialSubscriptionView.swift  there was only name and phone Pad. No Punctuation and - was possible. So "Meier**-**Schulze" was not possible in Current Environment. 