### PR TITLE
Fix dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,173 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/swift,objective-c,xcode,macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=swift,objective-c,xcode,macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Objective-C ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+### Objective-C Patch ###
+
+### Swift ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+
+
+
+
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+
+### Xcode ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+
+
+
+## Gcc Patch
+/*.gcno
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+# End of https://www.toptal.com/developers/gitignore/api/swift,objective-c,xcode,macos
+
+# Fonts
 *.ttf

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "NorthLib"]
+	path = NorthLib
+	url = git@github.com:nthies/NorthLib.git

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 iOS-App for reading the "taz" digital newspaper
 
+## Dependencies
+
+- Uses [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for dependency management 
+- Depends on [NorthLib](https://github.com/nthies/NorthLib) by @nthies
+
 ## Author
 
 Norbert Thies, norbert@taz.de

--- a/taz.neo.xcodeproj/project.pbxproj
+++ b/taz.neo.xcodeproj/project.pbxproj
@@ -66,22 +66,22 @@
 		AECCE11C23FBF3FE007C2276 /* MainNC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECCE11B23FBF3FE007C2276 /* MainNC.swift */; };
 		AECCE11E23FBF449007C2276 /* StartupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECCE11D23FBF449007C2276 /* StartupView.swift */; };
 		AED748A62383F1D600C09D2D /* ArticleDB.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = AED70C8E2243E0EB00487918 /* ArticleDB.xcdatamodel */; };
-		AED748AB238415B200C09D2D /* NorthLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE98512D2320F83900EAC9D8 /* NorthLib.framework */; };
 		AEF2DF2F244709CC00D1482D /* IssueCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF2DF2E244709CC00D1482D /* IssueCarousel.swift */; };
 		AEF2DF3324475A6200D1482D /* CarouselController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECAC8FC2440AF1F00D32175 /* CarouselController.swift */; };
 		AEF2DF35244766E400D1482D /* MomentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF2DF34244766E400D1482D /* MomentView.swift */; };
 		C794F23524FED184007168AC /* Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C794F23424FED184007168AC /* Helper.swift */; };
+		D84C92C32537331F00B9CE79 /* NorthLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D84C92BC253732C900B9CE79 /* NorthLib.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		AE98512C2320F83900EAC9D8 /* PBXContainerItemProxy */ = {
+		D84C92BB253732C900B9CE79 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AE9851272320F83800EAC9D8 /* NorthLib.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = AE7122C523197AFA00B715A8;
 			remoteInfo = NorthLib;
 		};
-		AE98512E2320F83900EAC9D8 /* PBXContainerItemProxy */ = {
+		D84C92BD253732C900B9CE79 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AE9851272320F83800EAC9D8 /* NorthLib.xcodeproj */;
 			proxyType = 2;
@@ -140,7 +140,7 @@
 		AE82262C232A70E000FFBE67 /* GraphQlSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQlSession.swift; sourceTree = "<group>"; };
 		AE822631232A717E00FFBE67 /* DataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataModel.swift; sourceTree = "<group>"; };
 		AE86486F248E274F007096B4 /* PdfTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfTest.swift; sourceTree = "<group>"; };
-		AE9851272320F83800EAC9D8 /* NorthLib.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = NorthLib.xcodeproj; path = ../NorthLib/NorthLib.xcodeproj; sourceTree = "<group>"; };
+		AE9851272320F83800EAC9D8 /* NorthLib.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = NorthLib.xcodeproj; path = NorthLib/NorthLib.xcodeproj; sourceTree = "<group>"; };
 		AEAABADD24641BFA001BE414 /* Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Const.swift; sourceTree = "<group>"; };
 		AEAAEB2B23FD867C00D1187F /* GqlAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GqlAuth.swift; sourceTree = "<group>"; };
 		AEAEE0002456D9EC00F627FE /* StartupVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupVC.swift; sourceTree = "<group>"; };
@@ -173,7 +173,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AED748AB238415B200C09D2D /* NorthLib.framework in Frameworks */,
+				D84C92C32537331F00B9CE79 /* NorthLib.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -294,15 +294,6 @@
 			path = TestController;
 			sourceTree = "<group>";
 		};
-		AE9851282320F83800EAC9D8 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				AE98512D2320F83900EAC9D8 /* NorthLib.framework */,
-				AE98512F2320F83900EAC9D8 /* Test.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		AEBAF55B219ACD1900566205 = {
 			isa = PBXGroup;
 			children = (
@@ -380,6 +371,15 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
+		D84C92B7253732C900B9CE79 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D84C92BC253732C900B9CE79 /* NorthLib.framework */,
+				D84C92BE253732C900B9CE79 /* Test.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -431,7 +431,7 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = AE9851282320F83800EAC9D8 /* Products */;
+					ProductGroup = D84C92B7253732C900B9CE79 /* Products */;
 					ProjectRef = AE9851272320F83800EAC9D8 /* NorthLib.xcodeproj */;
 				},
 			);
@@ -443,18 +443,18 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		AE98512D2320F83900EAC9D8 /* NorthLib.framework */ = {
+		D84C92BC253732C900B9CE79 /* NorthLib.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = NorthLib.framework;
-			remoteRef = AE98512C2320F83900EAC9D8 /* PBXContainerItemProxy */;
+			remoteRef = D84C92BB253732C900B9CE79 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		AE98512F2320F83900EAC9D8 /* Test.xctest */ = {
+		D84C92BE253732C900B9CE79 /* Test.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = Test.xctest;
-			remoteRef = AE98512E2320F83900EAC9D8 /* PBXContainerItemProxy */;
+			remoteRef = D84C92BD253732C900B9CE79 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */


### PR DESCRIPTION
Hello there,

a few days ago I found out that the taz-app is open source — this is really cool! 🥳 

I wanted to have a look at it but the project didn't build due to dependency issues: I didn't clone `NorthLib` to the correct folder and this wasn't documented anywhere.

This PR tries to fix it by introducing [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for depency management. It also changes the paths to the `NorthLib.xcodeproj`. As there's no Swift Package or Cocoapods or anything else for `NorthLib` this might be the easiest, most straight-forward option in my opinion.

There're three (documented) steps then to build this app:

1. Clone taz-neo.ios
2. Init submodules
3. CMD+B

This PR also adds some more things to the `.gitignore`-file for `.DS_Stores` and the usual suspects. There's also a [PR for `NorthLib`](https://github.com/nthies/NorthLib/pull/25) that should be merged before merging this PR. Otherwise the commit the submodules points to should be changed 😃 

What do you think?